### PR TITLE
integrating http servers with main scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 bins
-gatekeeper

--- a/Godeps
+++ b/Godeps
@@ -1,0 +1,1 @@
+github.com/tylerb/graceful   9a3d4236b03bb5d26f7951134d248f9d5510d599

--- a/main.go
+++ b/main.go
@@ -101,10 +101,10 @@ func main() {
 	var wg sync.WaitGroup
 	for _, server := range servers {
 		wg.Add(1)
-		go func() {
+		go func(server Server) {
 			server.Run()
 			wg.Done()
-		}()
+		}(server)
 	}
 
 	// configure a signal handler which will pass along signals to each

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,10 +11,10 @@ DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 
 cd "$DIR"
 
-
 if [[ $GATEKEEPER_DEV = "1" ]]; then
   echo "building gatekeeper in dev mode..."
   go build -o bins/gatekeeper .
+  ln -sf "$DIR/bins/gatekeeper" $GOPATH/bin/gatekeeper
 else
   echo "non-dev not supported yet..."
   exit 1


### PR DESCRIPTION
Went down a bit of a rabbit hole trying to set up deadline based HTTP servers
here. I started halfway implementing a "gatekeeper" _graceful_ server but it
seems like that ought to be a package later on. 

For now, let's use the `graceful` go library and wire up some basic ping
handlers (all here).

I think a next PR will introduce some scaffolding in the "gatekeeper" package
where we can start handling the _actual_ proxying work.
