### PR TITLE
*: app start/stop; plugins converted to use concrete error types

### DIFF
--- a/gatekeeper/loadbalancer.go
+++ b/gatekeeper/loadbalancer.go
@@ -98,7 +98,7 @@ func (l *loadBalancer) Stop(duration time.Duration) error {
 	for {
 		select {
 		case <-doneCh:
-			break
+			goto done
 		default:
 			if time.Now().After(timeout) {
 				errs.Add(fmt.Errorf("Did not stop quickly enough"))

--- a/gatekeeper/plugin.go
+++ b/gatekeeper/plugin.go
@@ -1,9 +1,13 @@
 package gatekeeper
 
+import (
+	"github.com/jonmorehouse/gatekeeper/shared"
+)
+
 type Plugin interface {
-	Start() error
-	Stop() error
-	Configure(map[string]interface{}) error
+	Start() *shared.Error
+	Stop() *shared.Error
+	Configure(map[string]interface{}) *shared.Error
 }
 
 type PluginType uint

--- a/gatekeeper/server.go
+++ b/gatekeeper/server.go
@@ -2,6 +2,7 @@ package gatekeeper
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/jonmorehouse/gatekeeper/shared"
@@ -9,6 +10,7 @@ import (
 
 type Server interface {
 	Start() error
+	StopAccepting() error
 	Stop(time.Duration) error
 }
 
@@ -19,14 +21,28 @@ type ProxyServer struct {
 	loadBalancer      LoadBalancerClient
 	requestModifier   RequestModifierClient
 	responseModifier  ResponseModifierClient
+	stopCh            chan interface{}
 }
 
 func (s *ProxyServer) Start() error {
-	fmt.Println("proxy server started ...")
+	log.Println("server started...")
+	for {
+		select {
+		case <-s.stopCh:
+			return nil
+		default:
+			time.Sleep(time.Second)
+		}
+	}
+	return nil
+}
+
+func (s *ProxyServer) StopAccepting() error {
 	return nil
 }
 
 func (s *ProxyServer) Stop(time.Duration) error {
 	fmt.Println("proxy server stopped...")
+	s.stopCh <- struct{}{}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -70,12 +70,11 @@ func main() {
 		if err := app.Stop(time.Second * 10); err != nil {
 			log.Fatal(err)
 		}
+		log.Println("Successfully shutdown application")
 	}()
 
 	// Start and run the application. This blocks
 	if err := app.Start(); err != nil {
 		log.Fatal(err)
 	}
-
-	time.Sleep(time.Second * 10)
 }

--- a/main.go
+++ b/main.go
@@ -61,20 +61,25 @@ func main() {
 		log.Fatal(err)
 	}
 
+	stopCh := make(chan interface{})
 	go func() {
 		signals := make(chan os.Signal, 1)
 		signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
 		<-signals
+		log.Println("Caught a signal...")
 		// by default, we give 10 seconds for the app to shut down gracefully
 		if err := app.Stop(time.Second * 10); err != nil {
 			log.Fatal(err)
 		}
 		log.Println("Successfully shutdown application")
+		stopCh <- struct{}{}
 	}()
 
 	// Start and run the application. This blocks
 	if err := app.Start(); err != nil {
 		log.Fatal(err)
 	}
+	// wait for the application to finish shutting down
+	<-stopCh
 }

--- a/plugin/loadbalancer/plugin.go
+++ b/plugin/loadbalancer/plugin.go
@@ -19,18 +19,18 @@ type Opts map[string]interface{}
 // this is the interface that gatekeeper sees
 type Plugin interface {
 	// standard plugin methods
-	Start() error
-	Stop() error
+	Start() *shared.Error
+	Stop() *shared.Error
 	// this isn't Opts, because we want to make this as general as possible
 	// for expressiveness between different plugins
-	Configure(map[string]interface{}) error
+	Configure(map[string]interface{}) *shared.Error
 	// Heartbeat is called by a plugin manager in the primary application periodically
-	Heartbeat() error
+	Heartbeat() *shared.Error
 
 	// loadbalancer specific methods
-	AddBackend(shared.UpstreamID, shared.Backend) error
-	RemoveBackend(shared.Backend) error
-	GetBackend(shared.UpstreamID) (shared.Backend, error)
+	AddBackend(shared.UpstreamID, shared.Backend) *shared.Error
+	RemoveBackend(shared.Backend) *shared.Error
+	GetBackend(shared.UpstreamID) (shared.Backend, *shared.Error)
 }
 
 type PluginDispenser struct {

--- a/plugin/loadbalancer/plugin.go
+++ b/plugin/loadbalancer/plugin.go
@@ -62,7 +62,7 @@ func RunPlugin(name string, impl Plugin) error {
 	return nil
 }
 
-func NewClient(name string, cmd string) (Plugin, error) {
+func NewClient(name string, cmd string) (Plugin, func(), error) {
 	pluginDispenser := PluginDispenser{}
 
 	client := plugin.NewClient(&plugin.ClientConfig{
@@ -76,14 +76,14 @@ func NewClient(name string, cmd string) (Plugin, error) {
 	rpcClient, err := client.Client()
 	if err != nil {
 		client.Kill()
-		return nil, err
+		return nil, func() {}, err
 	}
 
 	rawPlugin, err := rpcClient.Dispense(name)
 	if err != nil {
 		client.Kill()
-		return nil, err
+		return nil, func() {}, err
 	}
 
-	return rawPlugin.(Plugin), nil
+	return rawPlugin.(Plugin), func() { client.Kill() }, nil
 }

--- a/plugin/loadbalancer/rpc.go
+++ b/plugin/loadbalancer/rpc.go
@@ -9,24 +9,24 @@ import (
 
 type StartArgs struct{}
 type StartResp struct {
-	Err error
+	Err *shared.Error
 }
 
 type StopArgs struct{}
 type StopResp struct {
-	Err error
+	Err *shared.Error
 }
 
 type ConfigureArgs struct {
 	Opts map[string]interface{}
 }
 type ConfigureResp struct {
-	Err error
+	Err *shared.Error
 }
 
 type HeartbeatArgs struct{}
 type HeartbeatResp struct {
-	Err error
+	Err *shared.Error
 }
 
 type AddBackendArgs struct {
@@ -34,14 +34,14 @@ type AddBackendArgs struct {
 	Upstream shared.UpstreamID
 }
 type AddBackendResp struct {
-	Err error
+	Err *shared.Error
 }
 
 type RemoveBackendArgs struct {
 	Backend shared.Backend
 }
 type RemoveBackendResp struct {
-	Err error
+	Err *shared.Error
 }
 
 type GetBackendArgs struct {
@@ -49,7 +49,7 @@ type GetBackendArgs struct {
 }
 type GetBackendResp struct {
 	Backend shared.Backend
-	Err     error
+	Err     *shared.Error
 }
 
 type RPCServer struct {
@@ -99,68 +99,68 @@ type RPCClient struct {
 	client *rpc.Client
 }
 
-func (c *RPCClient) Start() error {
+func (c *RPCClient) Start() *shared.Error {
 	callArgs := StartArgs{}
 	callResp := StartResp{}
 	if err := c.client.Call("Plugin.Start", &callArgs, &callResp); err != nil {
-		return err
+		return shared.NewError(err)
 	}
 	return callResp.Err
 }
 
-func (c *RPCClient) Stop() error {
+func (c *RPCClient) Stop() *shared.Error {
 	callArgs := StopArgs{}
 	callResp := StopResp{}
 	if err := c.client.Call("Plugin.Stop", &callArgs, &callResp); err != nil {
-		return err
+		return shared.NewError(err)
 	}
 	return callResp.Err
 }
 
-func (c *RPCClient) Heartbeat() error {
+func (c *RPCClient) Heartbeat() *shared.Error {
 	callArgs := HeartbeatArgs{}
 	callResp := HeartbeatResp{}
 	if err := c.client.Call("Plugin.Heartbeat", &callArgs, &callResp); err != nil {
-		return err
+		return shared.NewError(err)
 	}
 	return callResp.Err
 }
 
-func (c *RPCClient) Configure(opts map[string]interface{}) error {
+func (c *RPCClient) Configure(opts map[string]interface{}) *shared.Error {
 	callArgs := ConfigureArgs{
 		Opts: opts,
 	}
 	callResp := ConfigureResp{}
 	if err := c.client.Call("Plugin.Configure", &callArgs, &callResp); err != nil {
-		return err
+		return shared.NewError(err)
 	}
 	return callResp.Err
 }
 
-func (c *RPCClient) AddBackend(upstream shared.UpstreamID, backend shared.Backend) error {
+func (c *RPCClient) AddBackend(upstream shared.UpstreamID, backend shared.Backend) *shared.Error {
 	callArgs := AddBackendArgs{
 		Upstream: upstream,
 		Backend:  backend,
 	}
 	callResp := AddBackendResp{}
 	if err := c.client.Call("Plugin.AddBackend", &callArgs, &callResp); err != nil {
-		return err
+		return shared.NewError(err)
 	}
 	return callResp.Err
 }
 
-func (c *RPCClient) RemoveBackend(backend shared.Backend) error {
+func (c *RPCClient) RemoveBackend(backend shared.Backend) *shared.Error {
 	callArgs := RemoveBackendArgs{
 		Backend: backend,
 	}
 	callResp := RemoveBackendResp{}
 	if err := c.client.Call("Plugin.RemoveBackend", &callArgs, &callResp); err != nil {
-		return err
+		return shared.NewError(err)
 	}
 	return callResp.Err
 }
 
-func (c *RPCClient) GetBackend(upstream shared.UpstreamID) (shared.Backend, error) {
+func (c *RPCClient) GetBackend(upstream shared.UpstreamID) (shared.Backend, *shared.Error) {
 	callArgs := GetBackendArgs{
 		Upstream: upstream,
 	}

--- a/plugin/upstream/manager.go
+++ b/plugin/upstream/manager.go
@@ -6,9 +6,9 @@ import (
 
 // manager is the interface which clients use to talk back to the gatekeeper parent process
 type Manager interface {
-	AddUpstream(shared.Upstream) error
-	RemoveUpstream(shared.UpstreamID) error
+	AddUpstream(shared.Upstream) *shared.Error
+	RemoveUpstream(shared.UpstreamID) *shared.Error
 
-	AddBackend(shared.UpstreamID, shared.Backend) error
-	RemoveBackend(shared.BackendID) error
+	AddBackend(shared.UpstreamID, shared.Backend) *shared.Error
+	RemoveBackend(shared.BackendID) *shared.Error
 }

--- a/plugin/upstream/manager_rpc.go
+++ b/plugin/upstream/manager_rpc.go
@@ -6,12 +6,15 @@ import (
 	"github.com/jonmorehouse/gatekeeper/shared"
 )
 
+type NotifyArgs struct{}
+type NotifyResp struct{}
+
 type AddUpstreamArgs struct {
 	Upstream shared.Upstream
 }
 
 type AddUpstreamResp struct {
-	Err error
+	Err *shared.Error
 }
 
 type RemoveUpstreamArgs struct {
@@ -19,7 +22,7 @@ type RemoveUpstreamArgs struct {
 }
 
 type RemoveUpstreamResp struct {
-	Err error
+	Err *shared.Error
 }
 
 type AddBackendArgs struct {
@@ -28,7 +31,7 @@ type AddBackendArgs struct {
 }
 
 type AddBackendResp struct {
-	Err error
+	Err *shared.Error
 }
 
 type RemoveBackendArgs struct {
@@ -36,58 +39,59 @@ type RemoveBackendArgs struct {
 }
 
 type RemoveBackendResp struct {
-	Err error
+	Err *shared.Error
 }
 
 type HeartbeatArgs struct{}
 type HeartbeatResp struct {
-	Err error
+	Err *shared.Error
 }
 
 type ManagerRPCClient struct {
 	client *rpc.Client
 }
 
-func (c *ManagerRPCClient) Notify() error {
-	return nil
+func (c *ManagerRPCClient) Notify() *shared.Error {
+	err := c.client.Call("Plugin.Notify", &NotifyArgs{}, &NotifyResp{})
+	return shared.NewError(err)
 }
 
-func (c *ManagerRPCClient) Heartbeat() error {
+func (c *ManagerRPCClient) Heartbeat() *shared.Error {
 	callArgs := HeartbeatArgs{}
 	callResp := HeartbeatResp{}
 
 	if err := c.client.Call("Plugin.Heartbeat", &callArgs, &callResp); err != nil {
-		return err
+		return shared.NewError(err)
 	}
 	return callResp.Err
 }
 
-func (c *ManagerRPCClient) AddUpstream(upstream shared.Upstream) error {
+func (c *ManagerRPCClient) AddUpstream(upstream shared.Upstream) *shared.Error {
 	callArgs := AddUpstreamArgs{
 		Upstream: upstream,
 	}
 	callResp := AddUpstreamResp{}
 
 	if err := c.client.Call("Plugin.AddUpstream", &callArgs, &callResp); err != nil {
-		return err
+		return shared.NewError(err)
 	}
 
 	return callResp.Err
 }
 
-func (c *ManagerRPCClient) RemoveUpstream(upstreamID shared.UpstreamID) error {
+func (c *ManagerRPCClient) RemoveUpstream(upstreamID shared.UpstreamID) *shared.Error {
 	callArgs := RemoveUpstreamArgs{
 		UpstreamID: upstreamID,
 	}
 	callResp := RemoveUpstreamResp{}
 
 	if err := c.client.Call("Plugin.RemoveUpstream", &callArgs, &callResp); err != nil {
-		return err
+		return shared.NewError(err)
 	}
 	return callResp.Err
 }
 
-func (c *ManagerRPCClient) AddBackend(upstreamID shared.UpstreamID, backend shared.Backend) error {
+func (c *ManagerRPCClient) AddBackend(upstreamID shared.UpstreamID, backend shared.Backend) *shared.Error {
 	callArgs := AddBackendArgs{
 		UpstreamID: upstreamID,
 		Backend:    backend,
@@ -95,19 +99,19 @@ func (c *ManagerRPCClient) AddBackend(upstreamID shared.UpstreamID, backend shar
 	callResp := AddBackendResp{}
 
 	if err := c.client.Call("Plugin.AddBackend", &callArgs, &callResp); err != nil {
-		return err
+		return shared.NewError(err)
 	}
 	return callResp.Err
 }
 
-func (c *ManagerRPCClient) RemoveBackend(backendID shared.BackendID) error {
+func (c *ManagerRPCClient) RemoveBackend(backendID shared.BackendID) *shared.Error {
 	callArgs := RemoveBackendArgs{
 		BackendID: backendID,
 	}
 	callResp := RemoveBackendResp{}
 
 	if err := c.client.Call("Plugin.RemoveBackend", &callArgs, &callResp); err != nil {
-		return err
+		return shared.NewError(err)
 	}
 	return callResp.Err
 }
@@ -117,7 +121,7 @@ type ManagerRPCServer struct {
 	connectedCh chan interface{}
 }
 
-func (s *ManagerRPCServer) Notify(*interface{}, *interface{}) error {
+func (s *ManagerRPCServer) Notify(*NotifyArgs, *NotifyResp) error {
 	s.connectedCh <- new(interface{})
 	return nil
 }

--- a/plugin/upstream/plugin.go
+++ b/plugin/upstream/plugin.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 
 	"github.com/hashicorp/go-plugin"
+	"github.com/jonmorehouse/gatekeeper/shared"
 )
 
 var Handshake = plugin.HandshakeConfig{
@@ -19,16 +20,16 @@ type Plugin interface {
 	// Pass along configuration options that are loosely defined from the
 	// parent plugin. Using anything in this dictionary needs to be done in
 	// as safe a way as possible!
-	Configure(map[string]interface{}) error
+	Configure(map[string]interface{}) *shared.Error
 
 	// Return an error if the plugin is not acting properly and/or needs to
 	// be rebooted by the parent.
-	Heartbeat() error
+	Heartbeat() *shared.Error
 
 	// Start the plugin. Note the Manager interface is used to send
 	// Upstream and Backend events back into the parent process.
-	Start(Manager) error
-	Stop() error
+	Start(Manager) *shared.Error
+	Stop() *shared.Error
 }
 
 // this is the interface that clients of this plugin use
@@ -37,13 +38,13 @@ type PluginClient interface {
 	// the scenes, the parent will pass in a manager implementation here
 	// which is then passed to the plugin implementer's start method. This
 	// is a little magical, but its controlled magic!
-	Configure(map[string]interface{}) error
-	Heartbeat() error
+	Configure(map[string]interface{}) *shared.Error
+	Heartbeat() *shared.Error
 
 	// NOTE this differs from the Plugin implementer side to make this a
 	// standard plugin and to work with the gatekeeper.PluginManager type.
-	Start() error
-	Stop() error
+	Start() *shared.Error
+	Stop() *shared.Error
 }
 
 // this is the pluginwrapper that individual plugins will use to create their

--- a/plugins/simple-loadbalancer/main.go
+++ b/plugins/simple-loadbalancer/main.go
@@ -25,13 +25,19 @@ func NewLoadBalancer() *LoadBalancer {
 }
 
 // no special configuration needed, but we implement these methods anyway for the interface
-func (l *LoadBalancer) Start() error                                { return nil }
-func (l *LoadBalancer) Stop() error                                 { return nil }
-func (l *LoadBalancer) Configure(opts map[string]interface{}) error { return nil }
-func (l *LoadBalancer) Heartbeat() error                            { return nil }
+func (l *LoadBalancer) Start() *shared.Error {
+	log.Println("simple-loadbalancer plugin started...")
+	return nil
+}
+func (l *LoadBalancer) Stop() *shared.Error {
+	log.Println("simple-loadbalancer plugin stopped...")
+	return nil
+}
+func (l *LoadBalancer) Configure(opts map[string]interface{}) *shared.Error { return nil }
+func (l *LoadBalancer) Heartbeat() *shared.Error                            { return nil }
 
 // actual implementation of methods used
-func (l *LoadBalancer) AddBackend(upstream shared.UpstreamID, backend shared.Backend) error {
+func (l *LoadBalancer) AddBackend(upstream shared.UpstreamID, backend shared.Backend) *shared.Error {
 	// TODO: handle duplicate backends here
 	if _, ok := l.upstreamBackends[upstream]; !ok {
 		l.upstreamBackends[upstream] = make([]shared.Backend, 0, 1)
@@ -40,7 +46,7 @@ func (l *LoadBalancer) AddBackend(upstream shared.UpstreamID, backend shared.Bac
 	return nil
 }
 
-func (l *LoadBalancer) RemoveBackend(deleted shared.Backend) error {
+func (l *LoadBalancer) RemoveBackend(deleted shared.Backend) *shared.Error {
 	found := false
 
 	for upstream, backends := range l.upstreamBackends {
@@ -57,17 +63,17 @@ func (l *LoadBalancer) RemoveBackend(deleted shared.Backend) error {
 	}
 
 	if !found {
-		return fmt.Errorf("Did not find backend")
+		return shared.NewError(fmt.Errorf("Did not find backend"))
 	}
 	return nil
 }
 
-func (l *LoadBalancer) GetBackend(upstream shared.UpstreamID) (shared.Backend, error) {
+func (l *LoadBalancer) GetBackend(upstream shared.UpstreamID) (shared.Backend, *shared.Error) {
 	backends, found := l.upstreamBackends[upstream]
 	if !found {
-		return shared.NilBackend, fmt.Errorf("Upstream not found")
+		return shared.NilBackend, shared.NewError(fmt.Errorf("Upstream not found"))
 	} else if len(backends) == 0 {
-		return shared.NilBackend, fmt.Errorf("No backends found")
+		return shared.NilBackend, shared.NewError(fmt.Errorf("No backends found"))
 	}
 
 	// pick a random backend for this upstream and return it
@@ -77,8 +83,8 @@ func (l *LoadBalancer) GetBackend(upstream shared.UpstreamID) (shared.Backend, e
 
 func main() {
 	rand.Seed(time.Now().Unix())
-	loadBalancer := LoadBalancer{}
-	if err := loadbalancer_plugin.RunPlugin("simple-loadbalancer", &loadBalancer); err != nil {
+	loadBalancer := NewLoadBalancer()
+	if err := loadbalancer_plugin.RunPlugin("simple-loadbalancer", loadBalancer); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/plugins/static-upstreams/main.go
+++ b/plugins/static-upstreams/main.go
@@ -13,21 +13,23 @@ type StaticUpstreams struct {
 	stopCh  chan interface{}
 }
 
-func (s *StaticUpstreams) Configure(map[string]interface{}) error {
+func (s *StaticUpstreams) Configure(map[string]interface{}) *shared.Error {
 	return nil
 }
 
-func (s *StaticUpstreams) Heartbeat() error {
+func (s *StaticUpstreams) Heartbeat() *shared.Error {
 	return nil
 }
 
-func (s *StaticUpstreams) Start(manager plugin.Manager) error {
+func (s *StaticUpstreams) Start(manager plugin.Manager) *shared.Error {
+	log.Println("static-upstreams plugin started...")
 	s.manager = manager
 	go s.worker()
 	return nil
 }
 
-func (s *StaticUpstreams) Stop() error {
+func (s *StaticUpstreams) Stop() *shared.Error {
+	log.Println("static-upstreams plugin stopped...")
 	return nil
 }
 
@@ -47,9 +49,11 @@ func (s *StaticUpstreams) worker() {
 
 	err = s.manager.AddBackend(upstr.ID, backend)
 	if err != nil {
-		log.Fatal(err)
+		log.Println("Static upstreams plugin was unable to emit a backend")
+		log.Println(err)
 	}
 
+	// hang around until the process exits!
 	for {
 		select {
 		case <-s.stopCh:


### PR DESCRIPTION
This is coming along nicely! So in this PR we introduce the following:
- [x] concrete errors passed between plugins
- [x] changes into the gatekeeper core to handle errors accordingly
- [x] app.Start and app.Stop methods 
- [x] changes to main binary to properly

After this PR, the application boots, boots dependencies and blocks waiting on the various servers. The main binary app accepts signals and can call `app.Stop()` to stop the server. We've tested the flow of the various plugins and have also ensured that ghost processes aren't hanging around. 

A few things to follow up on later:
- let's remove the annoying "signal ignored" log message for each plugin if possible
- it'd be nice to build out a nicer logger, this is probably going to be part of the log plugin work but still
- it seems like we ought to have a "plugin" package which attempts to abstract some of the work and some of the error handling between different plugin types
