### PR TITLE
event: introducing plugin scaffolding

### DIFF
--- a/plugin/event/plugin.go
+++ b/plugin/event/plugin.go
@@ -1,0 +1,217 @@
+package event
+
+import (
+	"fmt"
+	"net/rpc"
+	"os/exec"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/jonmorehouse/gatekeeper/shared"
+)
+
+var Handshake = plugin.HandshakeConfig{
+	ProtocolVersion:  1,
+	MagicCookieKey:   "gatekeeper|plugin-type",
+	MagicCookieValue: "event",
+}
+
+// Plugin exposes an interface that plugin creators can implement in order to
+// receive Events in the plugin lifecycle. The RPC wiring around this abstracts
+// away some of the type conversion and casting around errors and how we pass
+// metrics around.
+type Plugin interface {
+	Configure(map[string]interface{}) error
+	Heartbeat() error
+	Start() error
+	Stop() error
+
+	// Metric about things happening like Backends going in and out
+	GeneralMetric(*shared.GeneralMetric) error
+
+	// metrics about the life cycle of a request; for instance the internal
+	// latency, the total number of requests etc.
+	RequestMetric(*shared.RequestMetric) error
+
+	// A way of logging errors with context from the parent server
+	Error(error) error
+}
+
+// PluginClient exposes an interface that the gatekeeper process (or any user
+// of the event.Plugin) interface above would interact with. Underneath the
+// hood, it provides some abstraction to ensure that we are sending proper data
+// types over the wire and that we interact with the PluginRPC interface correctly.
+type PluginClient interface {
+	Configure(map[string]interface{}) error
+	Heartbeat() error
+	Start() error
+	Stop() error
+
+	// kill the underlying RPC connection, this should not be required, but is handy
+	Kill()
+
+	// Metric about things happening like Backends going in and out
+	WriteGeneralMetrics([]*shared.GeneralMetric) []error
+
+	// metrics about the life cycle of a request; for instance the internal
+	// latency, the total number of requests etc.
+	WriteRequestMetrics([]*shared.RequestMetric) []error
+
+	// A way of logging errors with context from the parent server
+	WriteErrors([]error) []error
+}
+
+type pluginClient struct {
+	// the underlying plugin connection that manages the plugin lifecycle
+	// at the process level
+	client *plugin.Client
+
+	// interface that we expose over the wire for transferring metrics in batches
+	pluginRPC PluginRPC
+}
+
+func NewPluginClient(client *plugin.Client, pluginRPC PluginRPC) PluginClient {
+	return &pluginClient{
+		client:    client,
+		pluginRPC: pluginRPC,
+	}
+}
+
+func (p *pluginClient) Configure(opts map[string]interface{}) error {
+	return p.pluginRPC.Configure(opts)
+}
+
+func (p *pluginClient) Heartbeat() error {
+	return p.pluginRPC.Heartbeat()
+}
+
+func (p *pluginClient) Start() error {
+	return p.pluginRPC.Start()
+}
+
+func (p *pluginClient) Stop() error {
+	return p.pluginRPC.Stop()
+}
+
+func (p *pluginClient) Kill() {
+	p.client.Kill()
+}
+
+func sharedErrsToErrs(input []*shared.Error) []error {
+	errs := make([]error, 0, len(input))
+	for _, err := range input {
+		errs = append(errs, err)
+	}
+
+	return errs
+}
+
+func (p *pluginClient) WriteGeneralMetrics(metrics []*shared.GeneralMetric) []error {
+	errs := p.pluginRPC.GeneralMetric(metrics)
+	return sharedErrsToErrs(errs)
+}
+
+func (p *pluginClient) WriteRequestMetrics(metrics []*shared.RequestMetric) []error {
+	errs := p.pluginRPC.RequestMetric(metrics)
+	return sharedErrsToErrs(errs)
+}
+
+func (p *pluginClient) WriteErrors(errors []error) []error {
+	sharedErrs := make([]*shared.Error, 0, len(errors))
+	for _, err := range errors {
+		sharedErrs = append(sharedErrs, shared.NewError(err))
+	}
+
+	errs := p.pluginRPC.Error(sharedErrs)
+	return sharedErrsToErrs(errs)
+}
+
+// PluginRPC is the type that is actually sent over the wire. Specifically, it
+// exposes concrete types for all errors to be sent back and forth.
+// NOTE, we send arrays of metrics over the wire, collecting errors and
+// returning them. This is so we can reduce the number of round trips across
+// the socket while also simplifying logic for the plugins implementing this
+// interface.
+type PluginRPC interface {
+	Configure(map[string]interface{}) *shared.Error
+	Heartbeat() *shared.Error
+	Start() *shared.Error
+	Stop() *shared.Error
+
+	GeneralMetric([]*shared.GeneralMetric) []*shared.Error
+	RequestMetric([]*shared.RequestMetric) []*shared.Error
+	Error([]*shared.Error) []*shared.Error
+}
+
+// PluginDispenser is the type that go-plugin interacts with for handling
+// Dispensary of client and server processes. Specifically it will _only_
+// create RPCClient and RPCServer types for consistency's sake.
+type PluginDispenser struct {
+	EventPlugin Plugin
+}
+
+func (d PluginDispenser) Server(b *plugin.MuxBroker) (interface{}, error) {
+	return &RPCServer{broker: b, impl: d.EventPlugin}, nil
+}
+
+func (d PluginDispenser) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+	return &RPCClient{broker: b, client: c}, nil
+}
+
+// RunPlugin should only be called by plugin processes. It accepts a type
+// implementing the Plugin interface above and builds plumbing around it to
+// call the various methods in the right context.
+func RunPlugin(name string, eventPlugin Plugin) error {
+	pluginDispenser := PluginDispenser{EventPlugin: eventPlugin}
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: Handshake,
+		Plugins: map[string]plugin.Plugin{
+			name: &pluginDispenser,
+		},
+	})
+	return nil
+}
+
+// NewClient creates a subprocess using the `go-plugin` provided plumbing and
+// exposes an interface to interact with plugin in an intuitive way. Its worth
+// mentioning that this `NewClient` is the only _blessed_ way to create an
+// instance of the event plugin as it specifically wraps the raw RPCClient with
+// a `PluginClient` type that allows for a nicer user interface.
+func NewClient(name string, cmd string) (PluginClient, error) {
+	pluginDispenser := PluginDispenser{}
+
+	client := plugin.NewClient(&plugin.ClientConfig{
+		HandshakeConfig: Handshake,
+		Plugins: map[string]plugin.Plugin{
+			name: &pluginDispenser,
+		},
+		Cmd: exec.Command(cmd),
+	})
+
+	rpcClient, err := client.Client()
+	if err != nil {
+		client.Kill()
+		return nil, err
+	}
+
+	// fetch an instance of the RPCClient from over the wire
+	rawPlugin, err := rpcClient.Dispense(name)
+	if err != nil {
+		client.Kill()
+		return nil, err
+	}
+
+	// cast the rawPlugin into the PluginRPC type which exposes concrete errors over the wire
+	pluginRPC, ok := rawPlugin.(PluginRPC)
+	if !ok {
+		client.Kill()
+		return nil, fmt.Errorf("Unable to cast plugin to the correct type")
+	}
+
+	// finally, build a new PluginClient which exposes a friendly interface
+	// for the gatekeeper process to use.
+	return &pluginClient{
+		// this is the go-plugin.Client
+		client:    client,
+		pluginRPC: pluginRPC,
+	}, nil
+}

--- a/plugin/event/plugin_rpc.go
+++ b/plugin/event/plugin_rpc.go
@@ -1,0 +1,197 @@
+package event
+
+import (
+	"net/rpc"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/jonmorehouse/gatekeeper/shared"
+)
+
+type StartArgs struct{}
+type StartResp struct {
+	Err *shared.Error
+}
+
+type StopArgs struct{}
+type StopResp struct {
+	Err *shared.Error
+}
+
+type ConfigureArgs struct {
+	Opts map[string]interface{}
+}
+type ConfigureResp struct {
+	Err *shared.Error
+}
+
+type HeartbeatArgs struct{}
+type HeartbeatResp struct {
+	Err *shared.Error
+}
+
+type GeneralMetricArgs struct {
+	Metrics []*shared.GeneralMetric
+}
+type GeneralMetricResp struct {
+	Errs []*shared.Error
+}
+
+type RequestMetricArgs struct {
+	Metrics []*shared.RequestMetric
+}
+type RequestMetricResp struct {
+	Errs []*shared.Error
+}
+
+type ErrorArgs struct {
+	Errors []*shared.Error
+}
+type ErrorResp struct {
+	Errs []*shared.Error
+}
+
+// implement the RPC server which the plugin runs, mapping to the Plugin
+// interface specified locally
+type RPCServer struct {
+	impl   Plugin
+	broker *plugin.MuxBroker
+}
+
+func (s *RPCServer) Start(args *StartArgs, resp *StartResp) error {
+	err := s.impl.Start()
+	resp.Err = shared.NewError(err)
+	return nil
+}
+
+func (s *RPCServer) Stop(args *StopArgs, resp *StopResp) error {
+	err := s.impl.Stop()
+	resp.Err = shared.NewError(err)
+	return nil
+}
+
+func (s *RPCServer) Heartbeat(args *HeartbeatArgs, resp *HeartbeatResp) error {
+	err := s.impl.Heartbeat()
+	resp.Err = shared.NewError(err)
+	return nil
+}
+
+func (s *RPCServer) Configure(args *ConfigureArgs, resp *ConfigureResp) error {
+	err := s.impl.Configure(args.Opts)
+	resp.Err = shared.NewError(err)
+	return nil
+}
+
+func (s *RPCServer) GeneralMetric(args *GeneralMetricArgs, resp *GeneralMetricResp) error {
+	errs := make([]*shared.Error, 0, len(args.Metrics))
+	for _, metric := range args.Metrics {
+		if err := s.impl.GeneralMetric(metric); err != nil {
+			errs = append(errs, shared.NewError(err))
+		}
+	}
+
+	resp.Errs = errs
+	return nil
+}
+
+func (s *RPCServer) RequestMetric(args *RequestMetricArgs, resp *RequestMetricResp) error {
+	errs := make([]*shared.Error, 0, len(args.Metrics))
+	for _, metric := range args.Metrics {
+		if err := s.impl.RequestMetric(metric); err != nil {
+			errs = append(errs, shared.NewError(err))
+		}
+	}
+
+	resp.Errs = errs
+	return nil
+}
+
+func (s *RPCServer) Error(args *ErrorArgs, resp *ErrorResp) error {
+	errs := make([]*shared.Error, 0, len(args.Errors))
+	for _, err := range args.Errors {
+		if implErr := s.impl.Error(err); err != nil {
+			errs = append(errs, shared.NewError(implErr))
+		}
+	}
+
+	resp.Errs = errs
+	return nil
+}
+
+type RPCClient struct {
+	broker *plugin.MuxBroker
+	client *rpc.Client
+}
+
+func (c *RPCClient) Start() *shared.Error {
+	callArgs := StartArgs{}
+	callResp := StartResp{}
+	if err := c.client.Call("Plugin.Start", &callArgs, &callResp); err != nil {
+		return shared.NewError(err)
+	}
+	return callResp.Err
+}
+
+func (c *RPCClient) Stop() *shared.Error {
+	callArgs := StopArgs{}
+	callResp := StopResp{}
+	if err := c.client.Call("Plugin.Stop", &callArgs, &callResp); err != nil {
+		return shared.NewError(err)
+	}
+	return callResp.Err
+}
+
+func (c *RPCClient) Heartbeat() *shared.Error {
+	callArgs := HeartbeatArgs{}
+	callResp := HeartbeatResp{}
+	if err := c.client.Call("Plugin.Heartbeat", &callArgs, &callResp); err != nil {
+		return shared.NewError(err)
+	}
+	return callResp.Err
+}
+
+func (c *RPCClient) Configure(opts map[string]interface{}) *shared.Error {
+	callArgs := ConfigureArgs{
+		Opts: opts,
+	}
+	callResp := ConfigureResp{}
+	if err := c.client.Call("Plugin.Configure", &callArgs, &callResp); err != nil {
+		return shared.NewError(err)
+	}
+	return callResp.Err
+}
+
+func (c *RPCClient) GeneralMetric(metrics []*shared.GeneralMetric) []*shared.Error {
+	callArgs := GeneralMetricArgs{
+		Metrics: metrics,
+	}
+	callResp := GeneralMetricResp{}
+
+	if err := c.client.Call("Plugin.GeneralMetric", &callArgs, &callResp); err != nil {
+		return []*shared.Error{shared.NewError(err)}
+	}
+	return callResp.Errs
+}
+
+func (c *RPCClient) RequestMetric(metrics []*shared.RequestMetric) []*shared.Error {
+	callArgs := RequestMetricArgs{
+		Metrics: metrics,
+	}
+	callResp := RequestMetricResp{}
+
+	if err := c.client.Call("Plugin.RequestMetric", &callArgs, &callResp); err != nil {
+		return []*shared.Error{shared.NewError(err)}
+	}
+	return callResp.Errs
+}
+
+func (c *RPCClient) Error(errors []*shared.Error) []*shared.Error {
+	callArgs := ErrorArgs{
+		Errors: errors,
+	}
+	callResp := ErrorResp{}
+
+	if err := c.client.Call("Plugin.Error", &callArgs, &callResp); err != nil {
+		return []*shared.Error{shared.NewError(err)}
+	}
+	return callResp.Errs
+}

--- a/plugins/event-logger/main.go
+++ b/plugins/event-logger/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+
+	event_plugin "github.com/jonmorehouse/gatekeeper/plugin/event"
+	"github.com/jonmorehouse/gatekeeper/shared"
+)
+
+// Plugin is a type that implements the event_plugin.Plugin interface
+type Plugin struct{}
+
+func (*Plugin) Start() error                           { return nil }
+func (*Plugin) Stop() error                            { return nil }
+func (*Plugin) Heartbeat() error                       { return nil }
+func (*Plugin) Configure(map[string]interface{}) error { return nil }
+
+func (*Plugin) GeneralMetric(metric *shared.GeneralMetric) error {
+	log.Println("general-metric received ...")
+	return nil
+}
+
+func (*Plugin) RequestMetric(metric *shared.RequestMetric) error {
+	log.Println("request-metric received ...")
+	return nil
+}
+
+func (*Plugin) Error(err error) error {
+	log.Println("error received ...")
+	return nil
+}
+
+func main() {
+	plugin := &Plugin{}
+	if err := event_plugin.RunPlugin("statsd-event-logger", plugin); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,9 +40,22 @@ echo "building plugin/loadbalancer package ..."
 cd "$DIR/plugin/upstream"
 go build .
 
+echo "building plugin/event package ..."
+cd "$DIR/plugin/event"
+go build .
+
+echo "building plugin/request package ..."
+cd "$DIR/plugin/request"
+go build .
+
+echo "building plugin/response package ..."
+cd "$DIR/plugin/response"
+go build .
+
 echo "building gatekeeper package ..."
 cd "$DIR/gatekeeper"
 go build .
+
 
 # 
 # Build the main gatekeeper application

--- a/shared/metrics.go
+++ b/shared/metrics.go
@@ -1,0 +1,91 @@
+package shared
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+type MetricKind uint
+
+const (
+	SomeMetric MetricKind = iota + 1
+	SomeOtherMetric
+)
+
+// declare names of each metric that are human readable
+var metricNames map[MetricKind]string = map[MetricKind]string{
+	SomeMetric:      "some_metric",
+	SomeOtherMetric: "some_other_metric",
+}
+
+func (m MetricKind) String() string {
+	name, ok := metricNames[m]
+	if !ok {
+		log.Fatal("MetricKind specified without name; this is a bug.")
+	}
+	return name
+}
+
+type Metric interface {
+	Name() string
+	Value() uint
+	Duration() time.Duration
+
+	HasCount() bool
+	HasDuration() bool
+}
+
+type GeneralMetric struct {
+	Kind  MetricKind
+	Count uint
+
+	Start time.Time
+	End   time.Time
+}
+
+func (g *GeneralMetric) Name() string {
+	return fmt.Sprintf("general|%s", g.Kind.String())
+}
+
+func (g *GeneralMetric) Duration() time.Duration {
+	return g.End.Sub(g.Start)
+}
+
+func (g *GeneralMetric) HasDuration() bool {
+	return g.Start != time.Time{} && g.End != time.Time{}
+}
+
+func (g *GeneralMetric) HasCount() bool {
+	return g.Count != 0
+}
+
+type RequestMetric struct {
+	Kind  MetricKind
+	Count uint
+
+	Start time.Time
+	End   time.Time
+
+	Upstream *Upstream
+	Backend  *Backend
+
+	Request  *Request
+	Response *Response
+}
+
+func (r *RequestMetric) Name() string {
+	return fmt.Sprintf("request|%s", r.Kind.String())
+}
+
+func (r *RequestMetric) Duration() time.Duration {
+	return r.End.Sub(r.Start)
+}
+
+func (r *RequestMetric) HasDuration() bool {
+	return r.Start != time.Time{} && r.End != time.Time{}
+}
+
+func (r *RequestMetric) HasCount() bool {
+	return r.Count != 0
+}


### PR DESCRIPTION
Initial scaffolding of the event plugin framework. 

As a first pass, we're introducing the following three methods:
- Error: for passing errors along to the plugin (this could be dropped later?)
- GeneralMetric: general metrics
- RequestMetric: request specific metrics (includes req, res, backend and upstream)
