### PR TITLE
optimization/cleanup: moving to use empty struct channel

### DIFF
--- a/gatekeeper/loadbalancer.go
+++ b/gatekeeper/loadbalancer.go
@@ -33,7 +33,7 @@ type loadBalancer struct {
 	// internal
 	eventCh  EventCh
 	listenID EventListenerID
-	stopCh   chan interface{}
+	stopCh   chan struct{}
 }
 
 func NewLoadBalancer(broadcaster EventBroadcaster, pluginManager PluginManager) LoadBalancer {
@@ -41,7 +41,7 @@ func NewLoadBalancer(broadcaster EventBroadcaster, pluginManager PluginManager) 
 		broadcaster:   broadcaster,
 		pluginManager: pluginManager,
 		eventCh:       make(EventCh),
-		stopCh:        make(chan interface{}),
+		stopCh:        make(chan struct{}),
 	}
 }
 
@@ -68,7 +68,7 @@ func (l *loadBalancer) Stop(duration time.Duration) error {
 		errs.Add(err)
 	}
 
-	doneCh := make(chan interface{})
+	doneCh := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(2)
 

--- a/gatekeeper/modifier.go
+++ b/gatekeeper/modifier.go
@@ -55,7 +55,7 @@ func (r *modifier) Stop(duration time.Duration) error {
 	errs := NewAsyncMultiError()
 
 	var wg sync.WaitGroup
-	doneCh := make(chan interface{})
+	doneCh := make(chan struct{})
 
 	for _, manager := range r.pluginManagers {
 		wg.Add(1)

--- a/gatekeeper/plugin_manager.go
+++ b/gatekeeper/plugin_manager.go
@@ -122,7 +122,7 @@ func (p *pluginManager) Stop(duration time.Duration) error {
 	}
 
 	// wait for the plugins to all finish, or otherwise timeout
-	doneCh := make(chan interface{})
+	doneCh := make(chan struct{})
 	go func() {
 		wg.Wait()
 		doneCh <- struct{}{}

--- a/gatekeeper/proxier.go
+++ b/gatekeeper/proxier.go
@@ -107,7 +107,7 @@ func (p *proxier) RoundTrip(rawReq *http.Request) (*http.Response, error) {
 	}()
 
 	// in a goroutine, wait for the request to finish.
-	doneCh := make(chan interface{})
+	doneCh := make(chan struct{})
 	go func() {
 		wg.Wait()
 		doneCh <- struct{}{}

--- a/gatekeeper/upstream_publisher.go
+++ b/gatekeeper/upstream_publisher.go
@@ -65,7 +65,7 @@ func (p *UpstreamPublisher) Stop(duration time.Duration) error {
 	errs := NewAsyncMultiError()
 
 	var wg sync.WaitGroup
-	doneCh := make(chan interface{})
+	doneCh := make(chan struct{})
 
 	// stop all pluginManagers, waiting for each one at the end!
 	for _, manager := range p.pluginManagers {

--- a/gatekeeper/upstream_requester.go
+++ b/gatekeeper/upstream_requester.go
@@ -24,7 +24,7 @@ type upstreamRequester struct {
 	broadcaster EventBroadcaster
 	listenID    EventListenerID
 	listenCh    EventCh
-	stopCh      chan interface{}
+	stopCh      chan struct{}
 
 	knownUpstreams      map[shared.UpstreamID]*shared.Upstream
 	upstreamsByHostname map[string]*shared.Upstream
@@ -36,7 +36,7 @@ func NewUpstreamRequester(broadcaster EventBroadcaster) UpstreamRequester {
 	return &upstreamRequester{
 		broadcaster: broadcaster,
 		listenCh:    make(chan Event),
-		stopCh:      make(chan interface{}),
+		stopCh:      make(chan struct{}),
 
 		knownUpstreams:      make(map[shared.UpstreamID]*shared.Upstream),
 		upstreamsByHostname: make(map[string]*shared.Upstream),

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	stopCh := make(chan interface{})
+	stopCh := make(chan struct{})
 	go func() {
 		signals := make(chan os.Signal, 1)
 		signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)

--- a/plugin/upstream/manager_rpc.go
+++ b/plugin/upstream/manager_rpc.go
@@ -118,11 +118,11 @@ func (c *ManagerRPCClient) RemoveBackend(backendID shared.BackendID) *shared.Err
 
 type ManagerRPCServer struct {
 	impl        Manager
-	connectedCh chan interface{}
+	connectedCh chan struct{}
 }
 
 func (s *ManagerRPCServer) Notify(*NotifyArgs, *NotifyResp) error {
-	s.connectedCh <- new(interface{})
+	s.connectedCh <- struct{}{}
 	return nil
 }
 

--- a/plugin/upstream/plugin_rpc.go
+++ b/plugin/upstream/plugin_rpc.go
@@ -173,7 +173,7 @@ func (c *PluginRPCClient) Start() *shared.Error {
 	// Start a ManagerRPCServer, which will take the impl, passing methods
 	// along to it and ensuring that the correct types are passed around in
 	// response.
-	connectedCh := make(chan interface{})
+	connectedCh := make(chan struct{})
 	go func() {
 		managerRPCServer := ManagerRPCServer{
 			impl:        c.manager,

--- a/plugins/static-upstreams/main.go
+++ b/plugins/static-upstreams/main.go
@@ -10,7 +10,7 @@ import (
 
 type StaticUpstreams struct {
 	manager upstream_plugin.Manager
-	stopCh  chan interface{}
+	stopCh  chan struct{}
 }
 
 func (s *StaticUpstreams) Configure(map[string]interface{}) error {
@@ -71,7 +71,7 @@ func (s *StaticUpstreams) worker() {
 
 func main() {
 	staticUpstreams := StaticUpstreams{
-		stopCh: make(chan interface{}),
+		stopCh: make(chan struct{}),
 	}
 
 	if err := upstream_plugin.RunPlugin("static-upstreams", &staticUpstreams); err != nil {


### PR DESCRIPTION
Micro optimization that was annoying me, but let's use a `chan struct{}` instead of `chan interface{}` learned from the golang src lib.
