### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Plugin-based http(s) communications.
 * current release: https://github.com/jonmorehouse/gatekeeper/releases/0.0.1
 
 
-[![build status](https://travis-ci.org/jonmorehouse/gatekeeper.svg?branch=master)]() [![GitHub release](https://img.shields.io/github/release/jonmorehouse/gatekeeper.svg?maxAge=2592000)]()[![Docker Pulls](https://img.shields.io/docker/pulls/jonmorehouse/gatekeeper.svg?maxAge=2592000)]()
+[![build status](https://travis-ci.org/jonmorehouse/gatekeeper.svg?branch=master)]() [![GitHub release](https://img.shields.io/github/release/jonmorehouse/gatekeeper.svg?maxAge=2592000)]()[![Docker Pulls](https://img.shields.io/docker/pulls/jonmorehouse/gatekeeper.svg?maxAge=2592000)]() [![](https://images.microbadger.com/badges/image/jonmorehouse/gatekeeper.svg)](https://microbadger.com/images/jonmorehouse/gatekeeper "Get your own image badge on microbadger.com")
 
 **Disclaimer** this isn't real software yet! Follow along at https://github.com/jonmorehouse/gatekeeper/pulls
 
@@ -216,3 +216,4 @@ Finally, during a request's lifecycle, the router is called to "get" a backend. 
 
 # Other
 
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [jonmorehouse/gatekeeper](https://hub.docker.com/r/jonmorehouse/gatekeeper/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/jonmorehouse/gatekeeper).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/jonmorehouse/gatekeeper.svg)](https://microbadger.com/images/jonmorehouse/gatekeeper)
